### PR TITLE
v2.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       run: dotnet build ./CustomCommands/CustomCommands.csproj --configuration Release --no-restore
 
     - name: Publish
-      run: dotnet publish --configuration Release --no-build --output ./out
+      run: dotnet publish ./CustomCommands/CustomCommands.csproj --configuration Release --no-build --output ./out
 
     - name: Zip artifacts
       run: |

--- a/CustomCommands/.gitignore
+++ b/CustomCommands/.gitignore
@@ -1,3 +1,5 @@
 /.vs
 /bin
 /obj
+
+TestingCommands.json

--- a/CustomCommands/Interfaces/IPluginUtilities.cs
+++ b/CustomCommands/Interfaces/IPluginUtilities.cs
@@ -8,5 +8,4 @@ public interface IPluginUtilities
     string[] SplitStringByCommaOrSemicolon(string str);
     void ExecuteServerCommands(Commands cmd, CCSPlayerController player);
     bool RequiresPermissions(CCSPlayerController player, Permission permissions);
-    string PadLeftColorTag(string input);
 }

--- a/CustomCommands/Services/LoadJson.cs
+++ b/CustomCommands/Services/LoadJson.cs
@@ -18,10 +18,11 @@ public class LoadJson : ILoadJson
     {
         var comms = new List<Commands>();
 
+        string defaultconfigpath = Path.Combine(path, "Commands.json");
+
         CheckForExampleFile(path);
 
         var pathofcommands = Path.Combine(path, "Commands");
-        var defaultconfigpath = Path.Combine(path, "Commands.json");
 
         var files = new List<string>();
 
@@ -34,7 +35,6 @@ public class LoadJson : ILoadJson
             files.Add(defaultconfigpath);
             Logger.LogInformation("Found default config file.");
         }
-        //
         else if (!File.Exists(defaultconfigpath) && files.Count == 0)
         {
             Logger.LogWarning("No Config file found. Please create plugins/CustomCommands/Commands.json or in plugins/CustomCommands/Commands/<name>.json");
@@ -58,6 +58,13 @@ public class LoadJson : ILoadJson
     // Check if the Command.json file exists. If not replace it with the example file
     public void CheckForExampleFile(string path)
     {
+        if (Directory.Exists(Path.Combine(path, "Commands")))
+        {
+            var files = Directory.GetFiles(Path.Combine(path, "Commands"), "*.json", SearchOption.AllDirectories);
+            if (files.Length > 0)
+                return;
+        }
+
         var defaultconfigpath = Path.Combine(path, "Commands.json");
         var exampleconfigpath = Path.Combine(path, "Commands.example.json");
         if (!File.Exists(defaultconfigpath))
@@ -65,7 +72,6 @@ public class LoadJson : ILoadJson
             File.Copy(exampleconfigpath, defaultconfigpath);
             Logger.LogInformation("Created default config file.");
         }
-        
     }
     public bool IsValidJsonSyntax(string path)
     {

--- a/CustomCommands/Services/PluginUtilities.cs
+++ b/CustomCommands/Services/PluginUtilities.cs
@@ -98,41 +98,4 @@ public class PluginUtilities : IPluginUtilities
             return true;
         }
     }
-    /// <summary>
-    /// Moves the color tag one space the the left if it's not already there.
-    /// Because the game doesn't support color tags at the start of a string.
-    /// </summary>
-    /// <param name="input"></param>
-    /// <returns></returns>
-    public string PadLeftColorTag(string input)
-    {
-        string[] colorTagList = new string[] {
-            "{DEFAULT}",
-            "{WHITE}",
-            "{DARKRED}",
-            "{RED}",
-            "{LIGHTRED}",
-            "{GREEN}",
-            "{LIME}",
-            "{OLIVE}",
-            "{ORANGE}",
-            "{GOLD}",
-            "{YELLOW}",
-            "{BLUE}",
-            "{DARKBLUE}",
-            "{LIGHTPURPLE}",
-            "{PURPLE}",
-            "{SILVER}",
-            "{BLUEGREY}",
-            "{GREY}",
-        };
-        foreach (var colorTag in colorTagList)
-        {
-            if (input.StartsWith(colorTag))
-            {
-                return " " + input;
-            }
-        }
-        return input;
-    }
 }

--- a/CustomCommands/Services/RegisterCommands.cs
+++ b/CustomCommands/Services/RegisterCommands.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using CounterStrikeSharp.API.Core.Plugin;
 using CustomCommands.Interfaces;
 using CustomCommands.Model;
@@ -33,16 +34,28 @@ public class RegisterCommands : IRegisterCommands
 
         for (int i = 0; i < aliases.Length; i++)
         {
-            plugin.AddCommand(aliases[i], com.Description, (player, info) =>
+            string alias = aliases[i];
+            plugin.AddCommand(alias, com.Description, (player, info) =>
             {
                 if (player == null) return;
                 
                 var command = com;
-                
-                if (info.ArgCount > 1)
-                    command = PluginGlobals.CustomCommands.Find(x => x.Command.Contains(aliases[i])) ?? com;
 
-                if (command.Permission.PermissionList.Count > 0 && command.Permission != null)
+                // Check if the command has arguments and if it does, check if the command exists and is the right one
+                if (info.ArgCount > 1)
+                {
+                    var findcommand = PluginGlobals.CustomCommands.Find(x => x.Command.Contains(alias + $" {info.ArgString}"));
+                    // Check if the command is the right one with the right arguments
+                    if (findcommand! != command)
+                        return;
+
+                    command = findcommand;
+                }
+                // This will exit the command if the command has arguments but the client didn't provide any
+                if (command!.Command.Contains(alias + " ") && info.ArgCount <= 1) 
+                    return;
+
+                if (command!.Permission.PermissionList.Count > 0 && command.Permission != null)
                     if (!PluginUtilities.RequiresPermissions(player, command.Permission)) 
                         return;
             

--- a/CustomCommands/Services/RegisterCommands.cs
+++ b/CustomCommands/Services/RegisterCommands.cs
@@ -38,10 +38,10 @@ public class RegisterCommands : IRegisterCommands
                 if (player == null) return;
                 
                 var command = com;
+                
+                Logger.LogInformation(info.ArgCount.ToString());
                 if (info.ArgCount > 0)
-                {
                     command = PluginGlobals.CustomCommands.Find(x => x.Command.Contains(aliases[i])) ?? com;
-                }
 
                 if (command.Permission.PermissionList.Count > 0 && command.Permission != null)
                     if (!PluginUtilities.RequiresPermissions(player, command.Permission)) 

--- a/CustomCommands/Services/RegisterCommands.cs
+++ b/CustomCommands/Services/RegisterCommands.cs
@@ -39,8 +39,7 @@ public class RegisterCommands : IRegisterCommands
                 
                 var command = com;
                 
-                Logger.LogInformation(info.ArgCount.ToString());
-                if (info.ArgCount > 0)
+                if (info.ArgCount > 1)
                     command = PluginGlobals.CustomCommands.Find(x => x.Command.Contains(aliases[i])) ?? com;
 
                 if (command.Permission.PermissionList.Count > 0 && command.Permission != null)
@@ -70,12 +69,12 @@ public class RegisterCommands : IRegisterCommands
 
             foreach (var alias in aliases)
             {
-                if (commandNames.Contains(alias))
+                if (commandNames.Contains(alias.ToLower()))
                 {
                     duplicateCommands.Add(com);
                     continue;
                 }
-                commandNames.Add(alias);
+                commandNames.Add(alias.ToLower());
             }
         }
         

--- a/CustomCommands/Services/ReplaceTagsFunction.cs
+++ b/CustomCommands/Services/ReplaceTagsFunction.cs
@@ -15,15 +15,13 @@ public class ReplaceTagsFunctions : IReplaceTagsFunctions
     private readonly IPluginGlobals PluginGlobals;
     private readonly PluginContext PluginContext;
     private readonly ILogger<CustomCommands> Logger;
-    private readonly IPluginUtilities PluginUtilities;
     
     public ReplaceTagsFunctions(IPluginGlobals PluginGlobals, IPluginContext PluginContext, 
-                                    ILogger<CustomCommands> Logger, IPluginUtilities PluginUtilities)
+                                    ILogger<CustomCommands> Logger)
     {
         this.PluginGlobals = PluginGlobals;
         this.PluginContext = (PluginContext as PluginContext)!;
         this.Logger = Logger;
-        this.PluginUtilities = PluginUtilities;
     }
 
     public string[] ReplaceTags(string[] input, CCSPlayerController player)
@@ -96,7 +94,7 @@ public class ReplaceTagsFunctions : IReplaceTagsFunctions
     public string ReplaceColorTags(string input)
     {
         // PadLeft the color tag if it's not already there because the game doesn't support color tags at the start of a string.
-        input = PluginUtilities.PadLeftColorTag(input);
+        input = PadLeftColorTag(input);
 
         Dictionary<string, string> replacements = new()
         {
@@ -163,5 +161,43 @@ public class ReplaceTagsFunctions : IReplaceTagsFunctions
         }
 
         return output.ToArray();
+    }
+
+    /// <summary>
+    /// Moves the color tag one space the the left if it's not already there.
+    /// Because the game doesn't support color tags at the start of a string.
+    /// </summary>
+    /// <param name="input"></param>
+    /// <returns></returns>
+    private string PadLeftColorTag(string input)
+    {
+        string[] colorTagList = new string[] {
+            "{DEFAULT}",
+            "{WHITE}",
+            "{DARKRED}",
+            "{RED}",
+            "{LIGHTRED}",
+            "{GREEN}",
+            "{LIME}",
+            "{OLIVE}",
+            "{ORANGE}",
+            "{GOLD}",
+            "{YELLOW}",
+            "{BLUE}",
+            "{DARKBLUE}",
+            "{LIGHTPURPLE}",
+            "{PURPLE}",
+            "{SILVER}",
+            "{BLUEGREY}",
+            "{GREY}",
+        };
+        foreach (var colorTag in colorTagList)
+        {
+            if (input.StartsWith(colorTag))
+            {
+                return " " + input;
+            }
+        }
+        return input;
     }
 }

--- a/CustomCommands/test.md
+++ b/CustomCommands/test.md
@@ -1,11 +1,11 @@
 ## Test this:
 
-* [ ] Test tag support for server commands
-* [ ] check if USERID tag is the right one from the console
-* [ ] check if the string pattern check works
-* [ ] check cooldown funktion for normal int and than object
-* [ ] check if padleft color tag works now
-  * [ ] If this works remove all spaced in the example files with color tags
-* [ ] check if command args works
+* [X] Test tag support for server commands
+* [X] check if USERID tag is the right one from the console
+* [X] check if the string pattern check works
+* [X] check cooldown funktion for normal int and than object
+* [X] check if padleft color tag works now
+  * [X] If this works remove all spaced in the example files with color tags
+* [X] check if command args works
   * [ ] check if duplicated commands still wont work with this feature
-* [ ] check if toggle feature works
+* [X] check if toggle feature works

--- a/CustomCommands/test.md
+++ b/CustomCommands/test.md
@@ -9,7 +9,3 @@
 * [ ] check if command args works
   * [ ] check if duplicated commands still wont work with this feature
 * [ ] check if toggle feature works
-
-
-
-test

--- a/Examples/Colors.json
+++ b/Examples/Colors.json
@@ -3,14 +3,14 @@
         "Title": "Rainbow",
         "Description": "rainbow command",
         "Command": "rainbow",
-        "Message": " {RED}R{ORANGE}A{YELLOW}I{GREEN}N{BLUE}B{DARKBLUE}O{PURPLE}W", 
+        "Message": "{RED}R{ORANGE}A{YELLOW}I{GREEN}N{BLUE}B{DARKBLUE}O{PURPLE}W", 
         "PrintTo": 0
     },
     {
         "Title": "All Colors",
         "Description": "This command displays all the colors that are available to use in the chat.",
         "Command": "colors",
-        "Message": "{DEFAULT}1, {WHITE}2 \n {DARKRED}3, {RED}4, {LIGHTRED}5\n {GREEN}6, {LIME}7, {OLIVE}8\n {ORANGE}9, {GOLD}10, {YELLOW}11\n {BLUE}12, {DARKBLUE}13\n {LIGHTPURPLE}14 {PURPLE}15 \n, {GREY}18",
+        "Message": "{DEFAULT}1, {WHITE}2 \n{DARKRED}3, {RED}4, {LIGHTRED}5\n{GREEN}6, {LIME}7, {OLIVE}8\n{ORANGE}9, {GOLD}10, {YELLOW}11\n{BLUE}12, {DARKBLUE}13\n{LIGHTPURPLE}14 {PURPLE}15 \n,{GREY}18",
         "PrintTo": 0
     }
 ]

--- a/Examples/MulitpleAliasesForOneCommand.json
+++ b/Examples/MulitpleAliasesForOneCommand.json
@@ -2,7 +2,7 @@
     {
         "Title": "Discord",
         "Description": "Command for Discord link",
-        "Command": "discord,dc,Discord", // User can type !discord or /discord, !dc or /dc and !Discord or /discord in chat
+        "Command": "discord,dc", // User can type !discord or /discord, !dc or /dc and !Discord or /discord in chat
         "Message": "{PREFIX}Discord: https://discord.gg/Z9JfJ9Y57C",
         "PrintTo": 0
     }

--- a/Examples/Tags.json
+++ b/Examples/Tags.json
@@ -75,5 +75,12 @@
         "Command": "playercount",
         "Message": "Current playercount: {PLAYERS}",
         "PrintTo": 0
+    },
+    {
+        "Title": "UserID",
+        "Description": "Displays Player #userid",
+        "Command": "userid",
+        "Message": "Current players userid: {USERID}",
+        "PrintTo": 0
     }
 ]


### PR DESCRIPTION
## What's New:
- Alias Creation for Commands: You can now create aliases for commands using a semicolon, as in "Command": "discord;dc".
- New Tag for User ID: Added a new tag {USERID} to retrieve the #userid of the individual who used the command (userid from 'status').
- Support for Tags in Server Commands: Enhanced functionality with the addition of tag support for server commands.
- Command Cooldown Feature: Introduced a command cooldown option. For more information, see [Cooldown.json](https://github.com/HerrMagiic/CSS-CreateCustomCommands/tree/main/Examples/Cooldown.json).
- Argument Support for Commands: Implemented support for command arguments, e.g., "Command": "test 1". Details are available at [CommandWithArguments.json](https://github.com/HerrMagiic/CSS-CreateCustomCommands/tree/main/Examples/CommandWithArguments.json).
- Toggle Feature for Server Commands: Added the ability to toggle server commands, such as sv_cheats. See [ToggleServerCommands.json](https://github.com/HerrMagiic/CSS-CreateCustomCommands/tree/main/Examples/ToggleServerCommands.json) for more information.

## Fixes:
- Example Ignoring in Command Folder: Fixed an issue where Command.example.json file were not ignored when a JSON file was present in the Commands folder.
- Color Display at String Start: Resolved a bug where colors were not displayed when color tag placed at the beginning of a string.
- Command Alias Case Sensitivity: Fixed a bug where the plugin did not recognize duplicated commands due to differing cases in aliases.
- Miscellaneous Minor Fixes: Implemented several small fixes to improve overall functionality.